### PR TITLE
fix: compile error when build .so using .a

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -52,7 +52,7 @@ libfastcommon.a: $(FAST_STATIC_OBJS)
 .c:
 	$(COMPILE) -o $@ $<  $(FAST_STATIC_OBJS) $(LIB_PATH) $(INC_PATH)
 .c.o:
-	$(COMPILE) -c -o $@ $<  $(INC_PATH)
+	$(COMPILE) -c -fPIC -o $@ $<  $(INC_PATH)
 .c.lo:
 	$(COMPILE) -c -fPIC -o $@ $<  $(INC_PATH)
 install:


### PR DESCRIPTION
```
src/libfastcommon.a(hash.o): relocation R_X86_64_32 against `.data' can not be used when making a shared object; recompile with -fPIC
```

env: Ubuntu 14.04, gcc 4.8