### PR TITLE
docs: fix simple typo, recveived -> received

### DIFF
--- a/src/sockopt.h
+++ b/src/sockopt.h
@@ -144,7 +144,7 @@ int tcpgets(int sock, char *s, const int size, const int timeout);
  *          data: the buffer
  *          size: buffer size (max bytes can receive)
  *          timeout: read timeout
- *          count: store the bytes recveived
+ *          count: store the bytes received
  *  return: error no, 0 success, != 0 fail
 */
 int tcprecvdata_ex(int sock, void *data, const int size, \
@@ -156,7 +156,7 @@ int tcprecvdata_ex(int sock, void *data, const int size, \
  *          data: the buffer
  *          size: buffer size (max bytes can receive)
  *          timeout: read timeout in seconds
- *          count: store the bytes recveived
+ *          count: store the bytes received
  *  return: error no, 0 success, != 0 fail
 */
 int tcprecvdata_nb_ex(int sock, void *data, const int size, \
@@ -168,7 +168,7 @@ int tcprecvdata_nb_ex(int sock, void *data, const int size, \
  *          data: the buffer
  *          size: buffer size (max bytes can receive)
  *          timeout: read timeout in milliseconds
- *          count: store the bytes recveived
+ *          count: store the bytes received
  *  return: error no, 0 success, != 0 fail
 */
 int tcprecvdata_nb_ms(int sock, void *data, const int size, \


### PR DESCRIPTION
There is a small typo in src/sockopt.h.

Should read `received` rather than `recveived`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md